### PR TITLE
fix: deploy

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@clafoutis/cli",
   "version": "0.1.0",
   "description": "GitOps powered design system CLI - generate and sync design tokens",
-  "author": "Dessert",
+  "author": "Dessert Labs",
   "license": "BUSL-1.1",
   "type": "module",
   "engines": {

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -2,7 +2,7 @@
   "name": "@clafoutis/generators",
   "version": "0.1.0",
   "description": "Design token generators for Clafoutis",
-  "author": "Dessert",
+  "author": "Dessert Labs",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@clafoutis/shared",
   "version": "0.1.0",
-  "private": true,
   "description": "Shared utilities for Clafoutis",
+  "author": "Dessert Labs",
+  "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,6 +13,9 @@
       "import": "./dist/index.js"
     }
   },
+  "files": [
+    "dist/**/*"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authorship information to "Dessert Labs" in package metadata across multiple packages (CLI, generators, and shared).
  * The shared package has been reconfigured for public availability: the private designation was removed, BUSL-1.1 licensing information was added, author information was set, and built artifact distribution was configured to include all distributed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->