### PR TITLE
Add monorepo support across Studio and CLI (`--cwd`, repo subfolder, build+release workflow)

### DIFF
--- a/.changeset/bright-rules-serve.md
+++ b/.changeset/bright-rules-serve.md
@@ -1,0 +1,5 @@
+---
+"@clafoutis/cli": patch
+---
+
+Add monorepo-friendly `--cwd` support across CLI commands and update producer workflow scaffolding to commit `build/**` artifacts before creating a GitHub release.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ npx clafoutis init --producer
 git push  # GitHub Action runs generate and creates release automatically
 ```
 
-> If you opted out of the GitHub workflow during init, run `npx clafoutis generate` locally before pushing.
+The default workflow generates `build/`, commits updated `build/**` back to the repository, and creates a GitHub Release.
+If you opted out of the GitHub workflow during init, run `npx clafoutis generate` locally before pushing.
 
 **Consumers** (application developers) pin to a version and sync:
 
@@ -143,6 +144,7 @@ Initialize configuration with an interactive wizard, or use flags for CI:
 ```bash
 npx clafoutis init --producer              # Interactive producer setup
 npx clafoutis init --consumer --repo X/Y   # Interactive consumer setup
+npx clafoutis init --producer --cwd ./packages/design-system
 npx clafoutis init --non-interactive       # Skip prompts, use flags/defaults
 npx clafoutis init --dry-run               # Preview without writing files
 ```
@@ -154,6 +156,7 @@ Transform tokens into platform-specific outputs:
 ```bash
 npx clafoutis generate                     # Use config file
 npx clafoutis generate --tailwind --figma  # Specify generators
+npx clafoutis generate --cwd ./packages/design-system
 npx clafoutis generate --dry-run           # Preview output
 ```
 
@@ -164,8 +167,22 @@ Download tokens from a GitHub Release:
 ```bash
 npx clafoutis sync                         # Sync if version changed
 npx clafoutis sync --force                 # Re-sync even if cached
+npx clafoutis sync --cwd ./apps/web
 npx clafoutis sync --dry-run               # Preview what would sync
 ```
+
+### Monorepo Usage
+
+Use `--cwd <path>` on all CLI commands when running from a monorepo root:
+
+```bash
+npx clafoutis init --producer --cwd ./packages/design-system
+npx clafoutis generate --cwd ./packages/design-system
+npx clafoutis format --cwd ./packages/design-system
+npx clafoutis sync --cwd ./apps/web
+```
+
+All relative paths in config/options are resolved from the provided `--cwd`. Producer output remains `./build` by default.
 
 ## Custom Generators
 

--- a/apps/cli/src/commands/format.ts
+++ b/apps/cli/src/commands/format.ts
@@ -3,12 +3,18 @@ import path from "node:path";
 
 import { logger } from "@clafoutis/shared";
 
+import {
+  resolveCommandCwd,
+  resolveInCwd,
+  validateCwdOption,
+} from "../utils/cwd";
 import { tokensDirNotFoundError } from "../utils/errors";
 
 interface FormatOptions {
   tokens?: string;
   check?: boolean;
   dryRun?: boolean;
+  cwd?: string;
 }
 
 /**
@@ -69,7 +75,9 @@ function formatJson(content: string): string {
  * Formats token files to ensure consistent JSON formatting.
  */
 export function formatCommand(options: FormatOptions): void {
-  const tokensDir = options.tokens || "./tokens";
+  validateCwdOption(options.cwd);
+  const commandCwd = resolveCommandCwd(options.cwd);
+  const tokensDir = resolveInCwd(commandCwd, options.tokens || "./tokens");
 
   if (!fs.existsSync(tokensDir)) {
     throw tokensDirNotFoundError(tokensDir);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -88,6 +88,7 @@ program
   .option("--tailwind", "Generate Tailwind output")
   .option("--figma", "Generate Figma variables")
   .option("-o, --output <dir>", "Output directory", "./build")
+  .option("--cwd <path>", "Run command as if from this directory")
   .option("--dry-run", "Preview changes without writing files")
   .action(withErrorHandling(generateCommand));
 
@@ -100,6 +101,7 @@ program
     "Path to config file",
     ".clafoutis/consumer.json",
   )
+  .option("--cwd <path>", "Run command as if from this directory")
   .option("--dry-run", "Preview changes without writing files")
   .action(withErrorHandling(syncCommand));
 
@@ -124,6 +126,7 @@ program
   .option("--force", "Overwrite existing configuration")
   .option("--dry-run", "Preview changes without writing files")
   .option("--non-interactive", "Skip prompts, use defaults or flags")
+  .option("--cwd <path>", "Run command as if from this directory")
   .action(withErrorHandling(initCommand));
 
 program
@@ -134,6 +137,7 @@ program
     "--check",
     "Check formatting without modifying files (fails if unformatted)",
   )
+  .option("--cwd <path>", "Run command as if from this directory")
   .option("--dry-run", "Preview changes without writing files")
   .action(withErrorHandling(formatCommand));
 

--- a/apps/cli/src/templates/workflow.ts
+++ b/apps/cli/src/templates/workflow.ts
@@ -1,6 +1,7 @@
 /**
  * Returns the GitHub Actions workflow YAML for automatic token releases.
- * Triggers on push to main when tokens change, generates outputs, and creates a release.
+ * Triggers on push to main when tokens change, generates outputs,
+ * commits build artifacts back to the repo, and creates a release.
  */
 export function getWorkflowTemplate(): string {
   return `name: Design Token Release
@@ -10,6 +11,7 @@ on:
     branches: [main]
     paths:
       - 'tokens/**'
+      - '.clafoutis/producer.json'
 
 jobs:
   release:
@@ -34,6 +36,18 @@ jobs:
 
       - name: Generate tokens
         run: npx clafoutis generate
+
+      - name: Commit generated build artifacts
+        run: |
+          if [ -z "$(git status --porcelain build)" ]; then
+            echo "No build changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add build
+          git commit -m "chore: update generated build artifacts"
+          git push
 
       - name: Get next version
         id: version

--- a/apps/cli/src/utils/cache.ts
+++ b/apps/cli/src/utils/cache.ts
@@ -1,16 +1,28 @@
 import fs from "fs/promises";
+import path from "path";
 
 const CACHE_DIR = ".clafoutis";
-const CACHE_FILE = `${CACHE_DIR}/cache`;
+const CACHE_FILE = "cache";
+
+function getCachePaths(commandCwd: string): { dir: string; file: string } {
+  const dir = path.resolve(commandCwd, CACHE_DIR);
+  return {
+    dir,
+    file: path.join(dir, CACHE_FILE),
+  };
+}
 
 /**
  * Reads the cached version from .clafoutis/cache file.
  * Returns null if the cache file does not exist.
  * Rethrows other errors (permissions, corruption, etc.).
  */
-export async function readCache(): Promise<string | null> {
+export async function readCache(
+  commandCwd = process.cwd(),
+): Promise<string | null> {
+  const { file } = getCachePaths(commandCwd);
   try {
-    return (await fs.readFile(CACHE_FILE, "utf-8")).trim();
+    return (await fs.readFile(file, "utf-8")).trim();
   } catch (err: unknown) {
     if (
       err instanceof Error &&
@@ -26,7 +38,11 @@ export async function readCache(): Promise<string | null> {
  * Writes the current version to the .clafoutis/cache file.
  * Creates the .clafoutis directory if it doesn't exist.
  */
-export async function writeCache(version: string): Promise<void> {
-  await fs.mkdir(CACHE_DIR, { recursive: true });
-  await fs.writeFile(CACHE_FILE, version);
+export async function writeCache(
+  version: string,
+  commandCwd = process.cwd(),
+): Promise<void> {
+  const { dir, file } = getCachePaths(commandCwd);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(file, version);
 }

--- a/apps/cli/src/utils/cwd.ts
+++ b/apps/cli/src/utils/cwd.ts
@@ -1,0 +1,42 @@
+import path from "path";
+
+import { ClafoutisError } from "./errors";
+
+/**
+ * Resolves the effective command working directory.
+ * Uses process.cwd() when no --cwd override is provided.
+ */
+export function resolveCommandCwd(cwdOverride?: string): string {
+  const cwd = cwdOverride?.trim() ? cwdOverride : process.cwd();
+  return path.resolve(cwd);
+}
+
+/**
+ * Resolves a path against command cwd when relative.
+ */
+export function resolveInCwd(commandCwd: string, targetPath: string): string {
+  return path.isAbsolute(targetPath)
+    ? path.resolve(targetPath)
+    : path.resolve(commandCwd, targetPath);
+}
+
+/**
+ * Converts an absolute path to a cwd-relative display path when possible.
+ */
+export function displayPath(commandCwd: string, absolutePath: string): string {
+  const rel = path.relative(commandCwd, absolutePath);
+  return rel && !rel.startsWith("..") ? rel : absolutePath;
+}
+
+/**
+ * Ensures cwd override is not empty whitespace when provided.
+ */
+export function validateCwdOption(cwdOverride?: string): void {
+  if (cwdOverride !== undefined && cwdOverride.trim() === "") {
+    throw new ClafoutisError(
+      "Invalid --cwd value",
+      "--cwd cannot be empty",
+      "Provide a valid directory path, for example: --cwd ./packages/design-system",
+    );
+  }
+}

--- a/apps/studio/src/components/layout/ProjectGate.tsx
+++ b/apps/studio/src/components/layout/ProjectGate.tsx
@@ -12,6 +12,7 @@ interface ProjectGateProps {
   tokenCount: number | null;
   fileCount: number | null;
   projectId: string;
+  tokensPath: string;
   onRetry: () => void;
   children: React.ReactNode;
 }
@@ -31,6 +32,7 @@ export function ProjectGate({
   tokenCount,
   fileCount,
   projectId,
+  tokensPath,
   onRetry,
   children,
 }: Readonly<ProjectGateProps>) {
@@ -75,8 +77,8 @@ export function ProjectGate({
         "Each token must include both $type and $value per the DTCG spec.";
     } else {
       message =
-        `No token files were found in the tokens/ directory of ${parsed.owner}/${parsed.repo}. ` +
-        "Make sure the repo has a tokens/ folder with .json files following the DTCG format.";
+        `No token files were found in the ${tokensPath}/ directory of ${parsed.owner}/${parsed.repo}. ` +
+        "Make sure that folder exists and contains .json files following the DTCG format.";
     }
 
     return (

--- a/apps/studio/src/components/views/DashboardView.stories.tsx
+++ b/apps/studio/src/components/views/DashboardView.stories.tsx
@@ -21,6 +21,7 @@ export const Default: Story = {
   args: {
     templates: TEMPLATES,
     publicRepoInput: "",
+    publicRepoSubfolder: "tokens",
     publicRepoError: "",
     isAuthenticated: false,
     authLoading: false,
@@ -28,6 +29,7 @@ export const Default: Story = {
     reposLoading: false,
     repos: undefined,
     onPublicRepoInputChange: noop,
+    onPublicRepoSubfolderChange: noop,
     onOpenPublicRepo: noop,
     onCreateFromTemplate: noop,
     onImportFiles: noop,

--- a/apps/studio/src/components/views/DashboardView.tsx
+++ b/apps/studio/src/components/views/DashboardView.tsx
@@ -55,134 +55,152 @@ const DashboardView = ({
   onSignIn,
   onShowRepos,
   onOpenRepo,
-}: DashboardViewProps) => (
-  <div className="mx-auto max-w-3xl space-y-10 overflow-y-auto px-4 py-6">
-    <div className="text-center">
-      <h1 className="text-3xl font-bold tracking-tight text-studio-text">
-        Clafoutis Studio
-      </h1>
-      <p className="mt-2 text-base text-studio-text-secondary">
-        Create, edit, and visualize your design tokens. Pick how you want to get
-        started.
-      </p>
-    </div>
+}: DashboardViewProps) => {
+  const handlePublicRepoSubmit = () => {
+    onOpenPublicRepo();
+  };
 
-    <div className="space-y-4">
-      <Card className="transition-shadow hover:shadow-md">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Plus size={18} className="text-studio-accent" />
-            Create a new design system
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="mb-4 text-sm text-studio-text-secondary">
-            Start from a template with pre-built tokens. You can download the
-            result as JSON files at any time.
-          </p>
-          <div className="flex flex-wrap gap-3">
-            {templates.map((tpl) => (
-              <button
-                key={tpl.id}
-                onClick={() => onCreateFromTemplate(tpl)}
-                className="flex-1 rounded-lg border border-studio-border bg-studio-bg-secondary p-4 text-left transition-colors hover:border-studio-accent hover:bg-studio-bg-tertiary"
-              >
-                <span className="flex items-center gap-2">
-                  <Palette size={16} className="text-studio-accent" />
-                  <span className="text-sm font-medium text-studio-text">
-                    {tpl.name}
+  const handlePublicRepoInputKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (e.key === "Enter") {
+      handlePublicRepoSubmit();
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-10 overflow-y-auto px-4 py-6">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold tracking-tight text-studio-text">
+          Clafoutis Studio
+        </h1>
+        <p className="mt-2 text-base text-studio-text-secondary">
+          Create, edit, and visualize your design tokens. Pick how you want to
+          get started.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <Card className="transition-shadow hover:shadow-md">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Plus size={18} className="text-studio-accent" />
+              Create a new design system
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="mb-4 text-sm text-studio-text-secondary">
+              Start from a template with pre-built tokens. You can download the
+              result as JSON files at any time.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {templates.map((tpl) => (
+                <button
+                  key={tpl.id}
+                  onClick={() => onCreateFromTemplate(tpl)}
+                  className="flex-1 rounded-lg border border-studio-border bg-studio-bg-secondary p-4 text-left transition-colors hover:border-studio-accent hover:bg-studio-bg-tertiary"
+                >
+                  <span className="flex items-center gap-2">
+                    <Palette size={16} className="text-studio-accent" />
+                    <span className="text-sm font-medium text-studio-text">
+                      {tpl.name}
+                    </span>
                   </span>
-                </span>
-                <span className="mt-1 block text-xs text-studio-text-muted">
-                  {tpl.description}
-                </span>
-              </button>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+                  <span className="mt-1 block text-xs text-studio-text-muted">
+                    {tpl.description}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
 
-      <Card className="transition-shadow hover:shadow-md">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Globe size={18} className="text-studio-accent" />
-            Open a public GitHub repo
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="mb-3 text-sm text-studio-text-secondary">
-            Paste a link or enter{" "}
-            <code className="rounded bg-studio-bg-tertiary px-1 py-0.5 text-xs">
-              owner/repo
-            </code>{" "}
-            to browse tokens from any public repository. No sign-in required.
-          </p>
-          <div className="flex gap-2">
-            <Input
-              placeholder="e.g. beauwilliams/clafoutis or https://github.com/..."
-              value={publicRepoInput}
-              onChange={(e) => onPublicRepoInputChange(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") onOpenPublicRepo();
-              }}
+        <Card className="transition-shadow hover:shadow-md">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Globe size={18} className="text-studio-accent" />
+              Open a public GitHub repo
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="mb-3 text-sm text-studio-text-secondary">
+              Paste a link or enter{" "}
+              <code className="rounded bg-studio-bg-tertiary px-1 py-0.5 text-xs">
+                owner/repo
+              </code>{" "}
+              to browse tokens from any public repository. No sign-in required.
+            </p>
+            <div className="flex gap-2">
+              <Input
+                placeholder="e.g. beauwilliams/clafoutis or https://github.com/..."
+                value={publicRepoInput}
+                onChange={(e) => onPublicRepoInputChange(e.target.value)}
+                onKeyDown={handlePublicRepoInputKeyDown}
+              />
+              <Input
+                placeholder="Subfolder (default: tokens)"
+                value={publicRepoSubfolder}
+                onChange={(e) => onPublicRepoSubfolderChange(e.target.value)}
+                onKeyDown={handlePublicRepoInputKeyDown}
+                className="max-w-64"
+              />
+              <Button onClick={handlePublicRepoSubmit}>Open</Button>
+            </div>
+            {publicRepoError && (
+              <p className="mt-2 text-xs text-studio-error">
+                {publicRepoError}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="transition-shadow hover:shadow-md">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Github size={18} />
+              {isAuthenticated ? "Your GitHub repos" : "Sign in with GitHub"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <GitHubSection
+              isAuthenticated={isAuthenticated}
+              authLoading={authLoading}
+              showRepos={showRepos}
+              reposLoading={reposLoading}
+              repos={repos}
+              onSignIn={onSignIn}
+              onShowRepos={onShowRepos}
+              onOpenRepo={onOpenRepo}
             />
-            <Input
-              placeholder="Subfolder (default: tokens)"
-              value={publicRepoSubfolder}
-              onChange={(e) => onPublicRepoSubfolderChange(e.target.value)}
-              className="max-w-64"
-            />
-            <Button onClick={onOpenPublicRepo}>Open</Button>
-          </div>
-          {publicRepoError && (
-            <p className="mt-2 text-xs text-studio-error">{publicRepoError}</p>
-          )}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
 
-      <Card className="transition-shadow hover:shadow-md">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Github size={18} />
-            {isAuthenticated ? "Your GitHub repos" : "Sign in with GitHub"}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <GitHubSection
-            isAuthenticated={isAuthenticated}
-            authLoading={authLoading}
-            showRepos={showRepos}
-            reposLoading={reposLoading}
-            repos={repos}
-            onSignIn={onSignIn}
-            onShowRepos={onShowRepos}
-            onOpenRepo={onOpenRepo}
-          />
-        </CardContent>
-      </Card>
+      <div className="flex items-center justify-center gap-6 border-t border-studio-border pt-6">
+        <button
+          onClick={onImportFiles}
+          className="flex items-center gap-2 text-sm text-studio-text-muted transition-colors hover:text-studio-text"
+        >
+          <Upload size={14} />
+          Import local JSON files
+        </button>
+        <span className="text-studio-border">|</span>
+        <button
+          onClick={() =>
+            globalThis.open(
+              "https://github.com/beauwilliams/clafoutis",
+              "_blank",
+            )
+          }
+          className="flex items-center gap-2 text-sm text-studio-text-muted transition-colors hover:text-studio-text"
+        >
+          <Download size={14} />
+          View Clafoutis on GitHub
+        </button>
+      </div>
     </div>
-
-    <div className="flex items-center justify-center gap-6 border-t border-studio-border pt-6">
-      <button
-        onClick={onImportFiles}
-        className="flex items-center gap-2 text-sm text-studio-text-muted transition-colors hover:text-studio-text"
-      >
-        <Upload size={14} />
-        Import local JSON files
-      </button>
-      <span className="text-studio-border">|</span>
-      <button
-        onClick={() =>
-          globalThis.open("https://github.com/beauwilliams/clafoutis", "_blank")
-        }
-        className="flex items-center gap-2 text-sm text-studio-text-muted transition-colors hover:text-studio-text"
-      >
-        <Download size={14} />
-        View Clafoutis on GitHub
-      </button>
-    </div>
-  </div>
-);
+  );
+};
 
 export default DashboardView;
 

--- a/apps/studio/src/components/views/DashboardView.tsx
+++ b/apps/studio/src/components/views/DashboardView.tsx
@@ -20,6 +20,7 @@ import { Loader } from "../ui/loader";
 interface DashboardViewProps {
   templates: TokenTemplate[];
   publicRepoInput: string;
+  publicRepoSubfolder: string;
   publicRepoError: string;
   isAuthenticated: boolean;
   authLoading: boolean;
@@ -27,6 +28,7 @@ interface DashboardViewProps {
   reposLoading: boolean;
   repos: GitHubRepo[] | undefined;
   onPublicRepoInputChange: (value: string) => void;
+  onPublicRepoSubfolderChange: (value: string) => void;
   onOpenPublicRepo: () => void;
   onCreateFromTemplate: (template: TokenTemplate) => void;
   onImportFiles: () => void;
@@ -38,6 +40,7 @@ interface DashboardViewProps {
 const DashboardView = ({
   templates,
   publicRepoInput,
+  publicRepoSubfolder,
   publicRepoError,
   isAuthenticated,
   authLoading,
@@ -45,6 +48,7 @@ const DashboardView = ({
   reposLoading,
   repos,
   onPublicRepoInputChange,
+  onPublicRepoSubfolderChange,
   onOpenPublicRepo,
   onCreateFromTemplate,
   onImportFiles,
@@ -121,6 +125,12 @@ const DashboardView = ({
               onKeyDown={(e) => {
                 if (e.key === "Enter") onOpenPublicRepo();
               }}
+            />
+            <Input
+              placeholder="Subfolder (default: tokens)"
+              value={publicRepoSubfolder}
+              onChange={(e) => onPublicRepoSubfolderChange(e.target.value)}
+              className="max-w-64"
             />
             <Button onClick={onOpenPublicRepo}>Open</Button>
           </div>

--- a/apps/studio/src/lib/project-metadata.ts
+++ b/apps/studio/src/lib/project-metadata.ts
@@ -1,0 +1,55 @@
+interface ProjectMetadata {
+  tokensPath?: string;
+}
+
+type ProjectMetadataStore = Record<string, ProjectMetadata>;
+
+const STORAGE_KEY = "studio-project-metadata";
+const DEFAULT_TOKENS_PATH = "tokens";
+
+function readStore(): ProjectMetadataStore {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as ProjectMetadataStore;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: ProjectMetadataStore): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // best-effort persistence
+  }
+}
+
+function normalizeTokensPath(pathValue: string): string {
+  const trimmed = pathValue.trim().replace(/^\/+|\/+$/g, "");
+  return trimmed || DEFAULT_TOKENS_PATH;
+}
+
+export function setProjectTokensPath(
+  projectId: string,
+  tokensPath: string,
+): void {
+  const store = readStore();
+  store[projectId] = {
+    ...store[projectId],
+    tokensPath: normalizeTokensPath(tokensPath),
+  };
+  writeStore(store);
+}
+
+export function getProjectTokensPath(projectId: string): string {
+  const store = readStore();
+  const tokensPath = store[projectId]?.tokensPath;
+  return typeof tokensPath === "string" && tokensPath.trim()
+    ? normalizeTokensPath(tokensPath)
+    : DEFAULT_TOKENS_PATH;
+}

--- a/apps/studio/src/pages/Dashboard.tsx
+++ b/apps/studio/src/pages/Dashboard.tsx
@@ -138,7 +138,7 @@ export function Dashboard() {
         onShowRepos={() => setShowRepos(true)}
         onOpenRepo={(owner, name) => {
           const projectId = `${owner}--${name}`;
-          setProjectTokensPath(projectId, "tokens");
+          setProjectTokensPath(projectId, publicRepoSubfolder);
           navigate({
             to: "/projects/$projectId/tokens",
             params: { projectId },

--- a/apps/studio/src/pages/Dashboard.tsx
+++ b/apps/studio/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/contexts/AuthProvider";
 import { listUserRepos, parseRepoInput } from "@/lib/github-api";
 import { importFromFiles } from "@/lib/local-import";
 import { regeneratePreview } from "@/lib/preview-css";
+import { setProjectTokensPath } from "@/lib/project-metadata";
 import { getTokenStore } from "@/lib/studio-api";
 import { TEMPLATES, type TokenTemplate } from "@/lib/templates";
 
@@ -24,6 +25,7 @@ export function Dashboard() {
   const { addAlert } = useAlerts();
   const navigate = useNavigate();
   const [publicRepoInput, setPublicRepoInput] = useState("");
+  const [publicRepoSubfolder, setPublicRepoSubfolder] = useState("tokens");
   const [publicRepoError, setPublicRepoError] = useState("");
   const [showRepos, setShowRepos] = useState(false);
 
@@ -42,11 +44,13 @@ export function Dashboard() {
       );
       return;
     }
+    const projectId = `${parsed.owner}--${parsed.repo}`;
+    setProjectTokensPath(projectId, publicRepoSubfolder);
     navigate({
       to: "/projects/$projectId/tokens",
-      params: { projectId: `${parsed.owner}--${parsed.repo}` },
+      params: { projectId },
     });
-  }, [publicRepoInput, navigate]);
+  }, [publicRepoInput, publicRepoSubfolder, navigate]);
 
   const handlePublicRepoInputChange = useCallback((value: string) => {
     setPublicRepoInput(value);
@@ -118,6 +122,7 @@ export function Dashboard() {
       <DashboardView
         templates={TEMPLATES}
         publicRepoInput={publicRepoInput}
+        publicRepoSubfolder={publicRepoSubfolder}
         publicRepoError={publicRepoError}
         isAuthenticated={isAuthenticated}
         authLoading={authLoading}
@@ -125,17 +130,20 @@ export function Dashboard() {
         reposLoading={reposLoading}
         repos={repos}
         onPublicRepoInputChange={handlePublicRepoInputChange}
+        onPublicRepoSubfolderChange={setPublicRepoSubfolder}
         onOpenPublicRepo={handleOpenPublicRepo}
         onCreateFromTemplate={handleCreateFromTemplate}
         onImportFiles={handleImportFiles}
         onSignIn={handleSignInThenBrowse}
         onShowRepos={() => setShowRepos(true)}
-        onOpenRepo={(owner, name) =>
+        onOpenRepo={(owner, name) => {
+          const projectId = `${owner}--${name}`;
+          setProjectTokensPath(projectId, "tokens");
           navigate({
             to: "/projects/$projectId/tokens",
-            params: { projectId: `${owner}--${name}` },
-          })
-        }
+            params: { projectId },
+          });
+        }}
       />
     </AppLayout>
   );

--- a/apps/studio/src/routes/projects/$projectId.tsx
+++ b/apps/studio/src/routes/projects/$projectId.tsx
@@ -17,6 +17,7 @@ import {
   onGenerationStatusChange,
   regeneratePreview,
 } from "@/lib/preview-css";
+import { getProjectTokensPath } from "@/lib/project-metadata";
 import { getEditorStore, getTokenStore } from "@/lib/studio-api";
 import { loadTokensFromGitHub } from "@/lib/token-loader";
 
@@ -55,6 +56,7 @@ function ProjectLayoutRoute() {
     if (loadedProjectRef.current === projectId) return;
 
     const parsed = parseProjectId(projectId);
+    const tokensPath = getProjectTokensPath(projectId);
     if (!parsed) {
       const count = getTokenStore().getState().resolvedTokens.length;
       setTokenCount(count);
@@ -73,7 +75,7 @@ function ProjectLayoutRoute() {
     loadTokensFromGitHub(
       parsed.owner,
       parsed.repo,
-      "tokens",
+      tokensPath,
       accessTokenRef.current,
     )
       .then(async (result) => {
@@ -164,6 +166,7 @@ function ProjectLayoutRoute() {
           tokenCount={tokenCount}
           fileCount={fileCount}
           projectId={projectId}
+          tokensPath={getProjectTokensPath(projectId)}
           onRetry={handleRetry}
         >
           <Outlet />

--- a/docs/distribution/README.md
+++ b/docs/distribution/README.md
@@ -67,12 +67,13 @@ npx clafoutis init --producer
 # Edit your tokens
 # tokens/colors/primitives.json
 
-# Push to GitHub - the workflow runs generate and creates a release automatically
+# Push to GitHub - the workflow runs generate, commits build/, and creates a release automatically
 git add . && git commit -m "Initial design system"
 git push origin main
 ```
 
 > If you opted out of the GitHub workflow during init, run `npx clafoutis generate` locally before pushing.
+> The default workflow always writes generated outputs to `build/` and commits `build/**` before creating the release.
 
 ### Producer Config: .clafoutis/producer.json
 
@@ -114,6 +115,7 @@ Options:
   --tailwind           Generate Tailwind output
   --figma              Generate Figma variables
   -o, --output <dir>   Output directory (default: ./build)
+  --cwd <path>         Run command as if from this directory
   --dry-run            Preview changes without writing files
 ```
 
@@ -123,8 +125,20 @@ When you run `npx clafoutis init --producer`, a GitHub Actions workflow is creat
 
 1. **Triggers** when you push changes to `tokens/` or `.clafoutis/producer.json`
 2. **Runs** `npx clafoutis generate` to create platform outputs
-3. **Creates a GitHub Release** with all generated files as assets
-4. **Auto-increments** the patch version (e.g., `v1.0.0` → `v1.0.1`)
+3. **Commits `build/**` back to the repository**
+4. **Creates a GitHub Release** with all generated files as assets
+5. **Auto-increments** the patch version (e.g., `v1.0.0` → `v1.0.1`)
+
+### Monorepo Usage
+
+Run commands from monorepo root by passing `--cwd`:
+
+```bash
+npx clafoutis init --producer --cwd ./packages/design-system
+npx clafoutis generate --cwd ./packages/design-system
+npx clafoutis format --cwd ./packages/design-system
+npx clafoutis sync --cwd ./apps/web
+```
 
 ### Manual Releases & Pre-release Versions
 
@@ -313,6 +327,7 @@ npx clafoutis sync [options]
 Options:
   -f, --force          Force sync even if versions match
   -c, --config <path>  Config file (default: .clafoutis/consumer.json)
+  --cwd <path>         Run command as if from this directory
   --dry-run            Preview changes without writing files
 ```
 


### PR DESCRIPTION
### Summary
- Adds **monorepo-aware repo loading in Studio** by introducing a separate **Subfolder** input when opening a GitHub repo.
- Adds **`--cwd <path>` support across CLI commands** (`init`, `generate`, `sync`, `format`) so commands can be run from monorepo root while targeting a package directory.
- Updates the default producer workflow scaffold to always:
  - generate outputs,
  - commit/push `build/**`,
  - create a GitHub release.
- Adds docs + a patch changeset for `@clafoutis/cli`.

### Why
Monorepo users need to:
1. Load tokens from subfolders (not just `tokens/` at repo root),
2. Run CLI commands from monorepo root without changing shell directory,
3. Keep build/release behavior consistent regardless of repo layout.

### Changes

#### Studio
- Added project metadata persistence for token subfolder (`tokensPath`) with default `tokens`.
- Dashboard now includes a **Subfolder** field next to repo input.
- Project loading now uses persisted `tokensPath` instead of hardcoded `tokens`.
- Empty-state copy now references the selected subfolder path.

#### CLI
- Added `--cwd <path>` option to:
  - `clafoutis init`
  - `clafoutis generate`
  - `clafoutis sync`
  - `clafoutis format`
- Introduced shared cwd utilities for consistent path resolution/validation.
- Updated `sync` cache and postSync execution to respect command cwd.
- Kept default behavior unchanged when `--cwd` is omitted.

#### Workflow scaffold
- Updated generated workflow to:
  - trigger on `tokens/**` and `.clafoutis/producer.json`,
  - run `clafoutis generate`,
  - commit/push updated `build/**`,
  - then create release assets and publish GitHub release.

#### Docs + release
- Updated root and distribution docs with monorepo usage examples (`--cwd`).
- Documented default workflow behavior (commit build artifacts + release).
- Added **patch changeset** for `@clafoutis/cli`.

### Notes
- `--cwd` is an override only; default remains current shell cwd.
- No monorepo-specific mode toggles were added; behavior is path-rooting only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cwd` option to all CLI commands (init, generate, format, sync) to run commands from any directory, enabling seamless monorepo support
  * Added customizable tokens path configuration for public repositories to specify token folder location
  * Enhanced GitHub workflow to automatically commit generated build artifacts before creating releases

* **Documentation**
  * Updated README with comprehensive monorepo usage examples and `--cwd` flag documentation across all commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->