### PR TITLE
fix: cwd path and default badge tokens

### DIFF
--- a/.changeset/tiny-brooms-grin.md
+++ b/.changeset/tiny-brooms-grin.md
@@ -1,0 +1,8 @@
+---
+"@clafoutis/cli": patch
+"@clafoutis/generators": patch
+---
+
+Fix generator cwd handling so `clafoutis generate --cwd <path>` always reads tokens and writes output relative to the provided working directory instead of the process root.
+
+Update the default starter badge tokens to use semantic state colors (info/success/warning/error) rather than slate-heavy values, improving out-of-the-box badge appearance.

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -166,8 +166,13 @@ export async function generateCommand(options: GenerateOptions): Promise<void> {
       } else {
         // Built-in generators from @clafoutis/generators package
         const builtInGenerators: Record<string, GeneratorModule> = {
-          tailwind: { generate: async () => tailwindGenerate(commandCwd) },
-          figma: { generate: async () => figmaGenerate(commandCwd) },
+          tailwind: {
+            generate: async (ctx) =>
+              tailwindGenerate(commandCwd, ctx.outputDir),
+          },
+          figma: {
+            generate: async (ctx) => figmaGenerate(commandCwd, ctx.outputDir),
+          },
         };
 
         if (!builtInGenerators[name]) {

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -166,8 +166,8 @@ export async function generateCommand(options: GenerateOptions): Promise<void> {
       } else {
         // Built-in generators from @clafoutis/generators package
         const builtInGenerators: Record<string, GeneratorModule> = {
-          tailwind: { generate: () => tailwindGenerate() },
-          figma: { generate: () => figmaGenerate() },
+          tailwind: { generate: async () => tailwindGenerate(commandCwd) },
+          figma: { generate: async () => figmaGenerate(commandCwd) },
         };
 
         if (!builtInGenerators[name]) {

--- a/apps/cli/src/templates/tokens/colors/components.dark.json
+++ b/apps/cli/src/templates/tokens/colors/components.dark.json
@@ -150,21 +150,21 @@
       "default": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.slate.1200}"
+          "$value": "{colors.state.info.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       },
       "secondary": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.slate.500}"
+          "$value": "{colors.state.info.bg}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.1200}"
+          "$value": "{colors.state.info.text}"
         }
       },
       "outline": {
@@ -184,41 +184,41 @@
       "info": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.blue.900}"
+          "$value": "{colors.state.info.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       },
       "success": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.green.900}"
+          "$value": "{colors.state.success.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       },
       "warning": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.yellow.900}"
+          "$value": "{colors.state.warning.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.state.warning.text}"
         }
       },
       "error": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.red.900}"
+          "$value": "{colors.state.error.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       }
     },

--- a/apps/cli/src/templates/tokens/colors/components.json
+++ b/apps/cli/src/templates/tokens/colors/components.json
@@ -150,21 +150,21 @@
       "default": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.slate.1200}"
+          "$value": "{colors.state.info.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       },
       "secondary": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.slate.300}"
+          "$value": "{colors.state.info.bg}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.1200}"
+          "$value": "{colors.state.info.text}"
         }
       },
       "outline": {
@@ -184,41 +184,41 @@
       "info": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.blue.900}"
+          "$value": "{colors.state.info.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       },
       "success": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.green.900}"
+          "$value": "{colors.state.success.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       },
       "warning": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.yellow.900}"
+          "$value": "{colors.state.warning.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.1200}"
+          "$value": "{colors.state.warning.text}"
         }
       },
       "error": {
         "bg": {
           "$type": "color",
-          "$value": "{colors.red.900}"
+          "$value": "{colors.state.error.primary}"
         },
         "text": {
           "$type": "color",
-          "$value": "{colors.slate.100}"
+          "$value": "{colors.text.inverse}"
         }
       }
     },

--- a/packages/generators/src/figma/figmaGenerator.ts
+++ b/packages/generators/src/figma/figmaGenerator.ts
@@ -30,8 +30,8 @@ interface FigmaCollection {
 }
 
 // Clean output directory
-function cleanDist(): void {
-  const distDir = path.resolve("build/figma");
+function cleanDist(cwd: string): void {
+  const distDir = path.resolve(cwd, "build/figma");
   try {
     fs.rmSync(distDir, { recursive: true, force: true });
     logger.info(`Removed ${distDir}`);
@@ -193,17 +193,18 @@ function getFigmaVariableType(tokenType: string): string {
 }
 
 // Main build function
-async function main(): Promise<void> {
-  cleanDist();
+async function main(cwd: string = process.cwd()): Promise<void> {
+  const resolvedCwd = path.resolve(cwd);
+  cleanDist(resolvedCwd);
 
-  const sourceFiles = ["tokens/**/*.json"];
+  const sourceFiles = [path.join(resolvedCwd, "tokens/**/*.json")];
 
   const SD = new StyleDictionary({
     source: sourceFiles,
     platforms: {
       figma: {
         transforms: ["figma/color", "figma/dimension", "figma/fontWeight"],
-        buildPath: "build/figma/",
+        buildPath: path.join(resolvedCwd, "build/figma/"),
         files: [
           {
             destination: "variables.json",

--- a/packages/generators/src/figma/figmaGenerator.ts
+++ b/packages/generators/src/figma/figmaGenerator.ts
@@ -30,16 +30,15 @@ interface FigmaCollection {
 }
 
 // Clean output directory
-function cleanDist(cwd: string): void {
-  const distDir = path.resolve(cwd, "build/figma");
+function cleanDist(buildPath: string): void {
   try {
-    fs.rmSync(distDir, { recursive: true, force: true });
-    logger.info(`Removed ${distDir}`);
+    fs.rmSync(buildPath, { recursive: true, force: true });
+    logger.info(`Removed ${buildPath}`);
   } catch {
     // ignore
   }
-  fs.mkdirSync(distDir, { recursive: true });
-  logger.success(`Created fresh ${distDir}`);
+  fs.mkdirSync(buildPath, { recursive: true });
+  logger.success(`Created fresh ${buildPath}`);
 }
 
 // Transformers for Figma
@@ -193,9 +192,15 @@ function getFigmaVariableType(tokenType: string): string {
 }
 
 // Main build function
-async function main(cwd: string = process.cwd()): Promise<void> {
+async function main(
+  cwd: string = process.cwd(),
+  outputDir?: string,
+): Promise<void> {
   const resolvedCwd = path.resolve(cwd);
-  cleanDist(resolvedCwd);
+  const buildPath = path.resolve(
+    outputDir ?? path.join(resolvedCwd, "build/figma/"),
+  );
+  cleanDist(buildPath);
 
   const sourceFiles = [path.join(resolvedCwd, "tokens/**/*.json")];
 
@@ -204,7 +209,7 @@ async function main(cwd: string = process.cwd()): Promise<void> {
     platforms: {
       figma: {
         transforms: ["figma/color", "figma/dimension", "figma/fontWeight"],
-        buildPath: path.join(resolvedCwd, "build/figma/"),
+        buildPath,
         files: [
           {
             destination: "variables.json",

--- a/packages/generators/src/tailwind/tailwindGenerator.ts
+++ b/packages/generators/src/tailwind/tailwindGenerator.ts
@@ -13,17 +13,16 @@ import tinycolor from "tinycolor2";
 
 // 0) CLEAN OUTPUT DIRECTORY
 // ----------------------------------------------------------------------------
-function cleanDist(cwd: string): void {
-  const distDir = path.resolve(cwd, "build/tailwind");
+function cleanDist(buildPath: string): void {
   try {
-    fs.rmSync(distDir, { recursive: true, force: true });
-    logger.info(`Removed ${distDir}`);
+    fs.rmSync(buildPath, { recursive: true, force: true });
+    logger.info(`Removed ${buildPath}`);
   } catch (err) {
-    logger.error(`Failed to remove ${distDir}: ${err}`);
+    logger.error(`Failed to remove ${buildPath}: ${err}`);
   }
 
-  fs.mkdirSync(distDir, { recursive: true });
-  logger.success(`Created fresh ${distDir}`);
+  fs.mkdirSync(buildPath, { recursive: true });
+  logger.success(`Created fresh ${buildPath}`);
 }
 
 // 1) TRANSFORMERS
@@ -336,11 +335,16 @@ export default {
 
 // 5) BUILD SCRIPTS
 // ----------------------------------------------------------------------------
-async function main(cwd: string = process.cwd()): Promise<void> {
+async function main(
+  cwd: string = process.cwd(),
+  outputDir?: string,
+): Promise<void> {
   const resolvedCwd = path.resolve(cwd);
-  const buildPath = path.join(resolvedCwd, "build", "tailwind") + "/";
+  const buildPath = path.resolve(
+    outputDir ?? path.join(resolvedCwd, "build", "tailwind"),
+  );
 
-  cleanDist(resolvedCwd);
+  cleanDist(buildPath);
 
   // Base styles
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generator command now respects the specified working directory/output directory so tokens are read and outputs written relative to the given path.

* **New Features**
  * Default badge and related component colors updated to semantic state tokens (info, success, warning, error) for better out-of-the-box appearance.
  * Component color mappings refined to rely on state-based tokens and inverse text where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->