### PR TITLE
fix: preserve publish diffs when restoring drafts

### DIFF
--- a/apps/studio/src/routes/projects/$projectId.tsx
+++ b/apps/studio/src/routes/projects/$projectId.tsx
@@ -90,7 +90,7 @@ function ProjectLayoutRoute() {
           const draft = await loadDraft(projectId);
           if (draft && !cancelled) {
             const store = getTokenStore();
-            store.getState().loadTokens(draft.tokenFiles);
+            store.getState().loadDraftTokens(draft.tokenFiles);
             await regeneratePreview(draft.tokenFiles);
             const draftTokenCount = store.getState().resolvedTokens.length;
             setTokenCount(draftTokenCount);
@@ -127,6 +127,10 @@ function ProjectLayoutRoute() {
   const isRemoteProject = parseProjectId(projectId) !== null;
   const handleDiscardChanges = useCallback(async () => {
     if (!isRemoteProject || discardingChanges) return;
+    const confirmed = globalThis.confirm(
+      "Discard all unsaved changes and reload tokens from GitHub?",
+    );
+    if (!confirmed) return;
     setDiscardingChanges(true);
     try {
       await clearDraft(projectId);


### PR DESCRIPTION
Keep the token baseline from GitHub when loading saved drafts so Publish correctly detects unsaved changes, and add a discard confirmation before reloading remote tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when discarding unsaved changes for remote projects. Users must confirm before changes are discarded and tokens are reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->